### PR TITLE
Add downloads badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 GUI Popup & Inspect - NetBeans Plugin
 =====================================
 
+![Downloads](https://img.shields.io/endpoint?url=https://openbeans.org/plugin-counter/api/17)
+
 Registers popup menu and inspect function for all regular components in IDE.
 
  - Use right click or Shift-F10 to show typical popup menu on various input boxes.


### PR DESCRIPTION
This PR adds a download counter badge to the README using the [netbeans-download-badges](https://github.com/emilianbold/netbeans-download-badges) service.

Changes

Added download counter badge to README.md

Notes
The badge displays the total number of downloads for this plugin from the NetBeans Plugin Portal. The counter is provided by openbeans.org and updates automatically.